### PR TITLE
 Login proccess speed #73

### DIFF
--- a/htdocs/app/controller/AutoWhitelistController.js
+++ b/htdocs/app/controller/AutoWhitelistController.js
@@ -75,13 +75,13 @@ Ext.define("Greyface.controller.AutoWhitelistController", {
     // Configure Store and connect with gridTable and gridPagingToolbar...
     wireupEmailStore: function () {
         var store = Ext.getStore("Greyface.store.AutoWhitelistEmailStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getEmailGrid().reconfigure(store)
         this.getEmailGridPagingToolbar().bindStore(store);
     },
     wireupDomainStore: function () {
         var store = Ext.getStore("Greyface.store.AutoWhitelistDomainStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getDomainGrid().reconfigure(store)
         this.getDomainGridPagingToolbar().bindStore(store);
     },

--- a/htdocs/app/controller/BlacklistController.js
+++ b/htdocs/app/controller/BlacklistController.js
@@ -74,13 +74,13 @@ Ext.define("Greyface.controller.BlacklistController", {
 
     wireupEmailStore: function () {
         var store = Ext.getStore("Greyface.store.BlacklistEmailStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getEmailGrid().reconfigure(store)
         this.getEmailGridPagingToolbar().bindStore(store);
     },
     wireupDomainStore: function () {
         var store = Ext.getStore("Greyface.store.BlacklistDomainStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getDomainGrid().reconfigure(store)
         this.getDomainGridPagingToolbar().bindStore(store);
     },

--- a/htdocs/app/controller/GreylistController.js
+++ b/htdocs/app/controller/GreylistController.js
@@ -65,13 +65,13 @@ Ext.define("Greyface.controller.GreylistController", {
 
     wireupStore: function () {
         var store = Ext.getStore("Greyface.store.GreylistStore");
-        store.load();
+        store.load(); // We need to load this store on startup
         this.getGrid().reconfigure(store)
         this.getGridPagingToolbar().bindStore(store);
 
         // wires up the store for the combobox which shows all users, after which the grid can be filtered.
         var userFilterStore = Ext.getStore("Greyface.store.UserFilterStore");
-        userFilterStore.load();
+        userFilterStore.load(); // We need to load this store on startup anyway!
         this.getGreylistUserFilterByCombobox().bindStore(userFilterStore);
         var scope = this
 

--- a/htdocs/app/controller/UserController.js
+++ b/htdocs/app/controller/UserController.js
@@ -91,19 +91,19 @@ Ext.define("Greyface.controller.UserController", {
 
     wireupUserAdminStore: function () {
         var store = Ext.getStore("Greyface.store.UserAdminStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getUserAdminGrid().reconfigure(store);
         this.getUserAdminGridPagingToolbar().bindStore(store);
     },
     wireupUserAliasStore: function () {
         var store = Ext.getStore("Greyface.store.UserAliasStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getUserAliasGrid().reconfigure(store);
         this.getUserAliasGridPagingToolbar().bindStore(store);
 
         // wires up the store for the combobox which shows all users, after which the grid can be filtered.
         var userAliasFilterStore = Ext.getStore("Greyface.store.UserAliasFilterStore");
-        userAliasFilterStore.load();
+        userAliasFilterStore.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getAliasFilterCombo().bindStore(userAliasFilterStore);
     },
 

--- a/htdocs/app/controller/WhitelistController.js
+++ b/htdocs/app/controller/WhitelistController.js
@@ -74,13 +74,13 @@ Ext.define("Greyface.controller.WhitelistController", {
 
     wireupEmailStore: function () {
         var store = Ext.getStore("Greyface.store.WhitelistEmailStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getEmailGrid().reconfigure(store)
         this.getEmailGridPagingToolbar().bindStore(store);
     },
     wireupDomainStore: function () {
         var store = Ext.getStore("Greyface.store.WhitelistDomainStore");
-        store.load();
+//        store.load(); // Login proccess speed #73 -> improved issue. No need to load all stores on startup!
         this.getDomainGrid().reconfigure(store)
         this.getDomainGridPagingToolbar().bindStore(store);
     },


### PR DESCRIPTION
Now we do not load all stores on startup.
This should help a bit to improve startup performance, but more
improvements don´t seem to be possible. It´s up to ExtJS that so many
things have to be loaded.
